### PR TITLE
Cleanup for 3.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.8, 3.9]
+        python-version: [3.8, 3.12]
         os: [ubuntu-latest]
 
     steps:

--- a/godaddyip/__main__.py
+++ b/godaddyip/__main__.py
@@ -1,6 +1,7 @@
 """
 Maintains A and CNAME records in Godaddy.
 """
+
 import argparse
 import json
 import logging
@@ -83,6 +84,10 @@ class Config:
 
 
 def main():
+    logging.basicConfig(
+        format="[%(asctime)s] %(levelname)s: %(message)s (%(filename)s:%(lineno)d)",
+        level=logging.INFO,
+    )
     parser = argparse.ArgumentParser(__doc__)
     parser.set_defaults(func=None)
     command_parser = parser.add_subparsers()
@@ -259,8 +264,4 @@ def store_value(tmp_folder, name, value):
 
 
 if __name__ == "__main__":
-    logging.basicConfig(
-        format="[%(asctime)s] %(levelname)s: %(message)s (%(filename)s:%(lineno)d)",
-        level=logging.INFO,
-    )
     main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
---index-url https://pypi.python.org/simple/
-
--e .
+requests==2.31.0
+pyyaml==6.0.1

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
         "requests==2.31.0",
         "pyyaml==6.0.1",
     ],
-    "test"=[
-        "black",
-    ],
+    extras_require={
+        "test": ["black"],
+    },
 )

--- a/setup.py
+++ b/setup.py
@@ -4,43 +4,35 @@ from os import path
 from setuptools import setup
 
 HERE = path.abspath(path.dirname(__file__))
-VERSION = "0.1.3"
+VERSION = "0.1.4"
 PACKAGE = "godaddyip"
 
 with _open(path.join(HERE, "README.md"), encoding="utf-8") as f:
     LONG_DESCRIPTION = f.read()
 
-    setup(
-        name=PACKAGE,
-        version=VERSION,
-        description="Maintains A and CNAME records matching current ip in Godaddy.",
-        long_description=LONG_DESCRIPTION,
-        long_description_content_type="text/markdown",
-        author="Pierre Penninckx",
-        author_email="ibizapeanut@gmail.com",
-        license="GPLv3",
-        packages=[PACKAGE.lower()],
-        url="https://github.com/ibizaman/" + PACKAGE.lower(),
-        download_url="https://github.com/ibizaman/{}/archive/{}.tar.gz".format(
-            PACKAGE.lower(), VERSION
-        ),
-        keywords=["godaddy", "dyndns"],
-        entry_points={
-            "console_scripts": ["{0}={0}.__main__:main".format(PACKAGE.lower())],
-        },
-        install_requires=[
-            "requests==2.31.0",
-            "pyyaml==5.4.1",
-        ],
-        extras_require={
-            "dev": [
-                "pylint == 1.7.2",
-            ],
-            "test": [
-                "black",
-                "coverage == 4.4.1",
-                "pytest == 3.1.3",
-                "pytest-cov == 2.5.1",
-            ],
-        },
-    )
+setup(
+    name=PACKAGE,
+    version=VERSION,
+    description="Maintains A and CNAME records matching current ip in Godaddy.",
+    long_description=LONG_DESCRIPTION,
+    long_description_content_type="text/markdown",
+    author="Pierre Penninckx",
+    author_email="ibizapeanut@gmail.com",
+    license="GPLv3",
+    packages=[PACKAGE.lower()],
+    url="https://github.com/ibizaman/" + PACKAGE.lower(),
+    download_url="https://github.com/ibizaman/{}/archive/{}.tar.gz".format(
+        PACKAGE.lower(), VERSION
+    ),
+    keywords=["godaddy", "dyndns"],
+    entry_points={
+        "console_scripts": ["{0}={0}.__main__:main".format(PACKAGE.lower())],
+    },
+    install_requires=[
+        "requests==2.31.0",
+        "pyyaml==6.0.1",
+    ],
+    "test"=[
+        "black",
+    ],
+)


### PR DESCRIPTION
- Move to version 0.1.4
- Fix requirements.txt to have actual requirements
- Move Github action to use 3.12
- Move logging setup into main() function so we actually get logging :)

Install and run locally
- `python3.12 -m venv --upgrade-deps /tmp/tg`
- `/tmp/tg/bin/pip install -e .[test]`
- `/tmp/tg/bin/black .`
- `/tmp/tg/bin/godaddyip run --config_files=/etc/godaddyip.yml --tmp_folder /tmp/cooper_godaddyip`
  - See files in /tmp/cooper_godaddyip