### PR TITLE
Add Support for updating AAAA record

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 requests==2.31.0
+pycurl==7.45.3
 pyyaml==6.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-requests==2.31.0
 requests==2.32.0
 pycurl==7.45.3
 pyyaml==6.0.1

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup(
     },
     install_requires=[
         "requests==2.31.0",
+        "pycurl==7.45.3",
         "pyyaml==6.0.1",
     ],
     extras_require={


### PR DESCRIPTION
- Add support for a aaaarecord config param
  - Could be the same as arecord to dual stack or not
- Added second call to `update_arecord` + `get_current_ip` to update AAAA record too
  - Added new `record_type` param for better logging and use of correct config param
  - Use it as the tmp filename checking for IP changes
  - Didn't bother to run in parallel as we don't need this to be "fast"
- Moved to using a HTTPS endpoint that is dual stacked
  - api.ipify.org only has A Records and is IPv4 only ...
  - i.e. moved endpoint URL from "api.ipify.org" to "icanhazip.com"
- Had to use pycurl as I could not get a requests to prefer IPv4 on a dual stacked host
  - I tried multiple ways but gave up and lived with adding an extra dependency
  - Added requirement to requirements.txt + setup.py

Known limitations:
- cnames only cname the A Record (not AAAA) unless you dualstack
  - I dual stack ...
- I couldn't get config.get("aaaarecord") to work natively ... so hacked using config._config.get(...) ...
  - Please comment if you see the bug there

As always, formatted with black
- `/tmp/tg/bin/black godaddyip/__main__.py`

Test:
- Ran on my home router manually making my own venv
  - `python3 -m venv --upgrade-deps /tmp/tg`
  - `/tmp/tg/bin/pip install -r requests.txt`
  - `/tmp/tg/bin/python godaddyip/__main__.py run --config_files=/etc/godaddyip.yml --tmp_folder /tmp/cooper_godaddyip`

```
[2024-05-06 04:29:31,149] INFO: Updating A record home. (__main__.py:217)
[2024-05-06 04:29:31,150] INFO: Same IP 47.33.51.91 as previous one, nothing to do. (__main__.py:220)
[2024-05-06 04:29:31,234] INFO: Updating AAAA record home. (__main__.py:217)
[2024-05-06 04:29:31,681] INFO: Updating CNAME record tahoe. (__main__.py:236)
[2024-05-06 04:29:31,681] INFO: Same alias as previous one, nothing to do. (__main__.py:239)
[2024-05-06 04:29:31,681] INFO: Updating CNAME record home1. (__main__.py:236)
[2024-05-06 04:29:31,681] INFO: Same alias as previous one, nothing to do. (__main__.py:239)
[2024-05-06 04:29:31,681] INFO: Sleeping for 5 minutes. (__main__.py:185)
```

Fixes #5